### PR TITLE
Fixing path for extern/include in Lab 4

### DIFF
--- a/Lab4.md
+++ b/Lab4.md
@@ -47,7 +47,7 @@ The accelerometer task uses some helper libraries that are delivered as part of 
    3. Enter the following value:
 
       ```c
-      ${workspace_loc:/${ProjName}/extern}
+      ${workspace_loc:/${ProjName}/extern/include}
       ```
       And click OK.
    4. Click Apply and Close.


### PR DESCRIPTION
Got build error following the instructions here. Added `/include` to the path solved it